### PR TITLE
Sundry Fixes to Improve Stability and Awesomeness

### DIFF
--- a/examples/simple-site/h9.yaml
+++ b/examples/simple-site/h9.yaml
@@ -3,7 +3,7 @@ target: "build"
 server:
   port: 8080
 aws:
-  domain: pandastrike.com
+  domain: panda-demo.com
   region: us-west-2
   site:
     index: index
@@ -12,8 +12,8 @@ aws:
   environments:
     staging:
       hostnames:
-        - david-staging
-        - david-beta-staging
+        - www-staging
+        - staging
       # cache:
       #   expires: 60 # 1 minute
       #   ssl: false
@@ -21,8 +21,8 @@ aws:
 
     production:
       hostnames:
-        - david
-        - david-beta
+        - www
+      apex: secondary
       cache:
         expires: 1800 # 30 minutes
         ssl: true

--- a/examples/simple-site/h9.yaml
+++ b/examples/simple-site/h9.yaml
@@ -10,7 +10,7 @@ aws:
     error: 404
 
   environments:
-    - title: staging
+    staging:
       hostnames:
         - david-staging
         - david-beta-staging
@@ -19,7 +19,7 @@ aws:
       #   ssl: false
       #   priceClass: 100
 
-    - title: production
+    production:
       hostnames:
         - david
         - david-beta
@@ -28,7 +28,7 @@ aws:
         ssl: true
         priceClass: 100
 
-    - title: nonSSL
+    nonSSL:
       hostnames:
         - david2
         - david2-beta

--- a/src/configuration/publish/compile.coffee
+++ b/src/configuration/publish/compile.coffee
@@ -12,12 +12,10 @@ module.exports = (config, env) ->
   }
 
   # Pull config data for the requested environment.
-  env = collect where {title: env}, aws.environments
-  if empty env
+  env = aws.environments[env]
+  if !env
     console.error "Cannot find config for specified environment. Aborting."
     throw new Error()
-  else
-    env = env[0]
 
   # Construct an array of full subdomains to feed the process.
   names = []

--- a/src/configuration/publish/compile.coffee
+++ b/src/configuration/publish/compile.coffee
@@ -22,7 +22,8 @@ module.exports = (config, env) ->
   # Construct an array of full subdomains to feed the process.
   names = []
   names.push (name + "." + aws.domain) for name in env.hostnames
-  names.push aws.domain if env.apex
+  names.unshift aws.domain  if env.apex == "primary"
+  names.push aws.domain     if env.apex == "secondary"
   out.aws.hostnames = names
 
   # Pull CloudFront (cdn / caching) info into the config

--- a/src/configuration/schema/definitions.yaml
+++ b/src/configuration/schema/definitions.yaml
@@ -33,11 +33,13 @@ environment:
     apex:
       description:
         In addition to the hostnames property, this optional flag will add
-        the apex domain to the list of hostnames.  The root is always treated
-        as a secondary hostname, and will be routed to the primary one
-        specified in the "hostnames" field.
+        the apex domain to the list of hostnames. Choosing "primary"
+        overrides the first name specified in the "hostnames" field.  All
+        hostnames will route to the apex. However, choosing "secondary" causes
+        the apex to be treated as a just another secondary hostname.
         Example "example.com" to "www.example.com"
-      type: boolean
+      type: string
+      enum: [ "primary", "secondary" ]
 
 
     cache:

--- a/src/configuration/schema/definitions.yaml
+++ b/src/configuration/schema/definitions.yaml
@@ -4,15 +4,8 @@ environment:
     distributions that are allocated on your behalf to deploy the static site.
   type: object
   additionalProperties: false
-  required: [ title, hostnames ]
+  required: [ hostnames ]
   properties:
-    title:
-      description:
-        Name of the environment.  Use "h9 publish <title>" to invoke this
-        configuration for the publish process.
-      type: string
-      minLength: 1
-
     hostnames:
       description:
         Name or names under which H9 creates subdomains and publishes your

--- a/src/configuration/schema/main.yaml
+++ b/src/configuration/schema/main.yaml
@@ -97,6 +97,10 @@ properties:
           Organizing configuration for those two cases into separate
           environments allows you to publish from the commandline by just
           invoking the name, not adjusting configuration each time.
-        type: array
-        minItems: 1
-        items: {$ref: "#/definitions/environment"}
+
+          environments is an object where the keys are the name of the given
+          environment and its value is its definition.  Use "h9 publish <title>"
+          to invoke this configuration within the publish process.
+        type: object
+        minProperties: 1
+        additionalProperties: {$ref: "#/definitions/environment"}

--- a/src/publish/bucket/cloudfront/distribution.coffee
+++ b/src/publish/bucket/cloudfront/distribution.coffee
@@ -83,9 +83,9 @@ module.exports = async (config, cf) ->
       DefaultCacheBehavior:
         TargetOriginId: originID
         ForwardedValues:
-          QueryString: false
+          QueryString: true
           Cookies:
-            Forward: "none"
+            Forward: "all"
           Headers:
             Quantity: 0
         MinTTL: 0

--- a/src/publish/bucket/s3.coffee
+++ b/src/publish/bucket/s3.coffee
@@ -1,4 +1,4 @@
-{async} = require "fairmont"
+{async, sleep} = require "fairmont"
 
 module.exports = (s3) ->
 
@@ -15,7 +15,7 @@ module.exports = (s3) ->
         when 403
           console.error "You are not authorized to modify this bucket."
           throw new Error()
-        when 404 
+        when 404
           exists = false
         else
           console.error "Unexpected reply from AWS", e
@@ -26,7 +26,7 @@ module.exports = (s3) ->
     # Create a new, empty S3 bucket.
     try
       yield s3.createBucket {Bucket: name, ACL: "public-read"}
-      false
+      yield sleep 15000
     catch e
       console.error "Failed to establish bucket.", e
       throw new Error()

--- a/src/publish/bucket/scan.coffee
+++ b/src/publish/bucket/scan.coffee
@@ -1,4 +1,4 @@
-{async, rest, sleep} = require "fairmont"
+{async, collect, pull} = require "fairmont"
 
 # Establishes what objects already exist up in S3.
 module.exports = (config, s3) ->
@@ -7,14 +7,13 @@ module.exports = (config, s3) ->
   async ->
     # Search your buckets for all hostnames. If they don't exist, make them.
     console.log "Scanning S3 bucket."
-    exists = yield bucket.establish config.aws.hostnames[0]
-    yield bucket.establish name for name in rest config.aws.hostnames
+    exists = (bucket.establish name for name in config.aws.hostnames)
+    yield collect pull exists
 
-    if exists
+    if exists[0]
       # The main buckets already exists.  Scan for objects and their md5 hashes.
       yield bucket.setACL config.aws.hostnames[0]
       yield bucket.list config.aws.hostnames[0], {}
     else
       # A new bucket was created, return an empty object
-      yield sleep 5000 # Avoids weird race condition with AWS API.
       {}

--- a/src/publish/bucket/sync.coffee
+++ b/src/publish/bucket/sync.coffee
@@ -16,7 +16,10 @@ module.exports = (config, s3) ->
   async ({dlist, ulist}) ->
     console.log "Syncing S3 bucket."
     total = (cat dlist, ulist).length
-    rl.close() if total == 0
+
+    if total == 0
+      rl.close()
+      console.log "  ***Warning: S3 Bucket is up-to-date.  Nothing to sync."
     currentIndex = 0
 
     printProgress = ->


### PR DESCRIPTION
This PR encompasses several small-ish tickets outstanding on Haiku9.

- #41 Allowing apex domains to be included in the site list, including as the primary one.
- #40 The CloudFront distributions H9 sets up will now forward cookies and query strings
- #27 H9 skips files larger than 5GB during the sync with a warning printed to the screen
- #44 Special thanks for a tip from Dan, environments are specified as a dictionary of names with data values, instead of an array with a `title` field.
- #39 I had to bunt on this one.  I'd need to look more in depth about how the bucket's existence is established among Amazon's various DBs.  For now, I just upped the wait on new buckets for a long period of time (15s).  I'm going to keep that ticket open, but this keeps it from showing up regularly when a user tries it out for the first time.
- #45 Instead of an overcomplicated delete-create scheme, we use upsert to change DNS records.

All of this is in the service of #36, to provide docs for users so they can go from zero to website themselves.  I'm still writing those into the main site, but I'm writing with the assumption the above features are part of H9.