### PR TITLE
Breaking tests up into multiple files

### DIFF
--- a/test/build_spec.coffee
+++ b/test/build_spec.coffee
@@ -1,0 +1,32 @@
+{join} = require "path"
+
+process.chdir join __dirname, "..", "examples", "simple-site"
+require "../src/index"
+
+{run} = require "panda-9000"
+assert = require "assert"
+{shell, sleep, call, exists} = require "fairmont"
+Amen = require "amen"
+
+Amen.describe "Haiku9 static-site generation", (context) ->
+
+  context.test "Run the build task", ->
+    yield shell "rm -rf build"
+    yield run "build"
+    yield sleep 1000
+    assert yield exists "build"
+
+    context.test "Compile Jade files", ->
+      assert yield exists "build/index.html"
+
+    context.test "Compile Stylus files", ->
+      assert yield exists "build/site.css"
+
+    context.test "Compile CoffeeScript files", ->
+      assert yield exists "build/site.js"
+
+    context.test "Passes through xml files", ->
+      assert yield exists "build/browserconfig.xml"
+
+    context.test "Passes through json files", ->
+      assert yield exists "build/manifest.json"

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,32 +1,8 @@
-{join} = require "path"
+targets = process.argv[2..]
 
-process.chdir join __dirname, "..", "examples", "simple-site"
-require "../src/index"
+if targets.length is 0
+  targets = [
+    "build"
+  ]
 
-{run} = require "panda-9000"
-assert = require "assert"
-{shell, sleep, call, exists} = require "fairmont"
-Amen = require "amen"
-
-Amen.describe "Haiku9 static-site generation", (context) ->
-
-  context.test "Run the build task", ->
-    yield shell "rm -rf build"
-    yield run "build"
-    yield sleep 1000
-    assert yield exists "build"
-
-    context.test "Compile Jade files", ->
-      assert yield exists "build/index.html"
-
-    context.test "Compile Stylus files", ->
-      assert yield exists "build/site.css"
-
-    context.test "Compile CoffeeScript files", ->
-      assert yield exists "build/site.js"
-
-    context.test "Passes through xml files", ->
-      assert yield exists "build/browserconfig.xml"
-
-    context.test "Passes through json files", ->
-      assert yield exists "build/manifest.json"
+require "./#{target}_spec" for target in targets


### PR DESCRIPTION
To avoid merge conflicts, breaking the test suite up into multiple files, referenced in `index.coffee`