### PR TITLE
Add CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "6"
   - "5"
   - "4"
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pandastrike/haiku9.svg)](https://travis-ci.org/pandastrike/haiku9)
+
 # Haiku9
 
 Haiku9 (H9 for short) is a static site generator. H9 supports:

--- a/package.json
+++ b/package.json
@@ -12,14 +12,15 @@
   "bin": {
     "h9": "./bin/h9"
   },
-  "engines" : {
-    "node" : ">=4.0.0"
+  "engines": {
+    "node": ">=4.0.0"
   },
   "engine-strict": true,
   "dependencies": {
     "aws-sdk": "2.2.48",
     "browserify": "^12.0.1",
     "chokidar": "^1.2.0",
+    "coffee-script": "^1.10.0",
     "coffeeify": "^2.0.1",
     "commander": "^2.9.0",
     "express": "^4.13.3",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "amen": "^1.0.0",
+    "coffee-script": "^1.10.0",
     "json": "^9.0.3"
   },
   "scripts": {


### PR DESCRIPTION
Solves #70 

Do we need to run the tests against any other version of Node? Right now I have it running against the latest stable version, latest v6, latest v5, and latest v4. The only bummer about doing that is it makes CI take a little longer. Since this is OSS my suggestion is we leave it and just deal with longer test cycles. Other opinions?

I currently have email notifications turned off, but would eventually like to create a `#panda-ci` channel in IRC and have it post updates there. (SEE: https://docs.travis-ci.com/user/notifications/#IRC-notification)