### PR TITLE
Await file creation before failing

### DIFF
--- a/test/helpers/build_helpers.coffee
+++ b/test/helpers/build_helpers.coffee
@@ -9,6 +9,8 @@ HOME_DIR = join __dirname, "..", ".."
 BASE_FIXTURE_DIR = join HOME_DIR, "test", "fixtures"
 BUILD_FILE = join __dirname, "builder.coffee"
 
+BUILD_TIMEOUT = 5000
+
 fixtureDir = (fixture) ->
   join BASE_FIXTURE_DIR, fixture
 
@@ -40,7 +42,15 @@ isBuilt = (fixture, expectedFile) ->
 # Asserts that the given test file exists under the fixture's build directory
 assertBuilt = (fixture, expectedFile) ->
   call ->
-    assert yield isBuilt(fixture, expectedFile), "File #{expectedFile} not built"
+    start = now = new Date()
+    built = false
+    while now - start <= BUILD_TIMEOUT
+      if built = yield isBuilt(fixture, expectedFile)
+        break
+      else
+        now = new Date()
+
+    assert built, "File #{expectedFile} not built"
 
 buildAndVerify = (fixture, expectedFile) ->
   call ->


### PR DESCRIPTION
Closes #69 

There is a timing issue where periodically a file doesn't exist for up to 40ms after writing it. Possibly related to issues with the `child_process` `exit` event.

This solves it by polling for the file until it exists, rather than failing immediately.

I've run the test suite on loop 200 times with no failures (previously it was failing about once every 10-20 times).

An alternative approach might be to get rid of `child_process` and just directly call `run` from the same process, but we'll have to force the tests to run synchronously for that approach, which is a fair amount of work, and isn't guaranteed to fix the problem.

If we decide to go that way in a future change, here is an example @dyoder has used:
https://github.com/pandastrike/p42/blob/rewrite/test/helpers.coffee#L12-L32
and
https://github.com/pandastrike/p42/blob/rewrite/test/foundation.coffee#L83