### PR TITLE
updated README with public docker image, version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# docker build . -t pandastrike/haiku9
+# docker tag pandastrike/haiku9 pandastrike/haiku9:1.1.0-beta-15
+# docker push pandastrike/haiku9
 FROM node:6
 
 RUN mkdir -p /usr/src/app

--- a/README.md
+++ b/README.md
@@ -31,12 +31,9 @@ npm install -g haiku9
 ### Docker
 
 ```shell
-git clone https://github.com/pandastrike/haiku9.git
-cd haiku9
-docker build -t h9 .
+docker pull pandastrike/haiku9
+docker tag pandastrike/haiku9 h9
 ```
-
-NOTE: Once we publish to Docker Hub, you will be able use `docker pull pandastrike/h9` instead of the above clone/build.
 
 ## Configuration
 
@@ -77,7 +74,7 @@ docker run -it --rm -v "$PWD":/usr/src/app -p 1337:1337 h9 serve
 NOTE: To install your app's npm modules via the `h9` Docker image:
 
 ```shell
-docker run -it --rm -v "$PWD":/usr/src/app --entrypoint="npm" haiku9 install
+docker run -it --rm -v "$PWD":/usr/src/app --entrypoint="npm" h9 install
 ```
 
 ## Compilation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "1.1.0-beta-14",
+  "version": "1.1.0-beta-15",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
README changes b/c `pandastrike/haiku9` published to DockerHub. Test-drive with any `haiku9`-driven site:

```
docker pull pandastrike/haiku9
docker tag pandastrike/haiku9 h9
docker run -it --rm -v "$PWD":/usr/src/app -p 1337:1337 h9 serve
```

Version bump b/c #90 was merged.