### PR TITLE
Support HTMLs Both With and Without Extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "1.1.0-beta-15",
+  "version": "1.1.0-beta-16",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Added the property of HTML files to be published as both with and without the .html extension to support path navigation (no extension) and import support (with extension).  This mimics the behavior of h9 serve.