### PR TITLE
Add Force Flag to Force Publish All the Things (Haiku-97)

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -34,14 +34,15 @@ call ->
   program
     .command('publish [env]')
     .description('deploy Website assets from "target" to AWS infrastructure')
+    .option("-f, --force", "force the upload of all files, ignoring cloud sync comparisons")
     .action(
-      (env)->
+      (env, options)->
         if !env
           console.error "No environment has been provided."
           console.error "Usage: h9 publish <environment>"
           process.exit 1
 
-        run "publish", [env]
+        run "publish", [env, options]
     )
 
 

--- a/src/publish/bucket/dns/dns.coffee
+++ b/src/publish/bucket/dns/dns.coffee
@@ -51,6 +51,7 @@ module.exports = (config, route53) ->
         # Escape if there's nothing to change.
         desired = addUpsert(source, hostname).ResourceRecordSet
         current = record[0]
+        delete current.ResourceRecords if empty current.ResourceRecords
         return null if deepEqual desired, current
 
       # Add an update to the DNS changeList.

--- a/src/publish/index.coffee
+++ b/src/publish/index.coffee
@@ -2,7 +2,7 @@
 {async, empty} = require "fairmont"
 {define} = require "panda-9000"
 
-define "publish", async (env) ->
+define "publish", async (env, options) ->
   config = require("../configuration/publish")(env)
 
   bucket = yield require("./bucket")(config)
@@ -11,7 +11,7 @@ define "publish", async (env) ->
   remoteFiles = yield bucket.scan()
   localFiles = yield local.scan()
 
-  actions = local.reconcile localFiles, remoteFiles
+  actions = local.reconcile localFiles, remoteFiles, options.force
   yield bucket.sync actions
 
   yield bucket.web.enable()

--- a/src/publish/local.coffee
+++ b/src/publish/local.coffee
@@ -30,7 +30,7 @@ module.exports =
     table
 
   # Produce an array of tasks to make the S3 bucket sync with the local files.
-  reconcile: (local, remote) ->
+  reconcile: (local, remote, force) ->
     # Files need to be uploaded or deleted from S3.
     dlist = []
     ulist = []
@@ -38,10 +38,22 @@ module.exports =
     # Ignore keys that signify a directory, instead of a flat data object.
     delete remote[k] for k, v of remote when k.match /.*\/$/
 
+    # Queue for deletion remote files that do not exist locally.
     dlist.push k for k, v of remote when !local[k] && !local[k + ".html"]
 
-    for k, v of local
-      obj = k.split(".html")[0]    # In S3, file is stripped of ".html" ext
-      ulist.push {file: k, hash: v} if !remote[obj] || v != remote[obj].hash
+    # Queue for upload local files.
+    if force
+      # The "--force" flag overrides reconciliation and queues everything.
+      ulist.push {file: k, hash: v} for k, v of local
+    else
+      # Check for files lacking remote counterpart or SHA hash match.
+      needsUpdate = (k, h) -> !remote[k] || h != remote[k].hash
+      for k, v of local
+        ulist.push {file: k, hash: v} if needsUpdate(k, v)
+
+        # For HTML files, we need to also check for files without extension.
+        if k.indexOf(".html") > -1 && !needsUpdate(k, v)
+          obj = k.split(".html")[0]    # stripped of ".html"
+          ulist.push {file: k, hash: v} if !remote[obj] || v != remote[obj].hash
 
     {dlist, ulist}


### PR DESCRIPTION
fixes #97 
Added the "force" flag to ask Haiku9 to upload everything in the build directory, regardless of the comparison result.  Corrected the DNS update detection for HTTP-only serving.

### How to Test
Get a project that you'd like to push, and get a test environment that uses HTTP-only serving (to be faster than using a cloudfront distribution).  Push once to sync, and then push again to confirm you get the message `***Warning: S3 Bucket is up-to-date.  Nothing to sync.`.  Then publish again with the `-f` flag and watch it upload everything.

I've also corrected the DNS record checking, so it will properly tell you that DNS is up to date.