### PR TITLE
This allows bower and h9 to play nicely together:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "1.1.0-beta-18",
+  "version": "1.1.0-beta-19",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [

--- a/src/survey/bundle.coffee
+++ b/src/survey/bundle.coffee
@@ -10,13 +10,16 @@ browserify = require "browserify"
 coffeeify = require "coffeeify"
 {save, render} = Asset = require "../asset"
 
+{isNodeModulesPath, isBowerComponentsPath} = require "../utils"
+
 type = Type.define Asset
 
 define "survey/bundle", ->
   {source} = require "../configuration"
   go [
     glob "**/package.json", source
-    reject isMatch /node_modules/
+    reject isNodeModulesPath
+    reject isBowerComponentsPath
     map context source
     tee ({target}) -> target.extension = ".js"
     map (context) -> include (Type.create type), context

--- a/src/survey/jade.coffee
+++ b/src/survey/jade.coffee
@@ -6,7 +6,7 @@ glob} = require "fairmont"
 {define, context, jade} = require "panda-9000"
 {save, render} = Asset = require "../asset"
 Data = require "../data"
-{pathWithUnderscore} = require "../utils"
+{pathWithUnderscore, isBowerComponentsPath} = require "../utils"
 
 type = Type.define Asset
 
@@ -15,6 +15,7 @@ define "survey/jade", ["data"], ->
   go [
     glob "**/*.jade", source
     reject pathWithUnderscore
+    reject isBowerComponentsPath
     map context source
     tee (context) -> Data.augment context
     tee ({target}) -> target.extension = ".html"

--- a/src/survey/markdown.coffee
+++ b/src/survey/markdown.coffee
@@ -5,7 +5,7 @@ Type, isType, Method, glob, read} = require "fairmont"
 {define, context, jade} = require "panda-9000"
 {save, render} = Asset = require "../asset"
 Data = require "../data"
-{pathWithUnderscore} = require "../utils"
+{pathWithUnderscore, isBowerComponentsPath} = require "../utils"
 
 type = Type.define Asset
 
@@ -14,6 +14,7 @@ define "survey/markdown", ["data"], ->
   go [
     glob "**/*.md", source
     reject pathWithUnderscore
+    reject isBowerComponentsPath
     map context source
     tee (context) -> Data.augment context
     tee ({target}) -> target.extension = ".html"

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -3,3 +3,7 @@
 module.exports =
 
   pathWithUnderscore: (path) -> isMatch /(^|\/)_/, path
+
+  isBowerComponentsPath: (path) -> isMatch /bower_components/, path
+
+  isNodeModulesPath: (path) -> isMatch /node_modules/, path


### PR DESCRIPTION
- If you run `bower install` from the `www` folder and then run `h9 build` you will get a lot of errors. This is because Haiku9 is trying to process and bundle files located within the `bower_components` directory.
- Haiku9 no longer tries to survey or process files within the bower components directory and you can run `bower install` from the `www` directory followed by `h9 build` without any errors now. 
- Previously H9 was trying to load js modules that weren't downloaded, process jade, process markdown, and bundle js 
- Since we are using `docker-compose` to run our local dev environment the `bower_components` folder is on a docker volume located at `/usr/src/app/www/bower_components` instead of being located at `www/bower_components`
   - When we run `h9 build` we aren’t copying any bower components into the build folder because there isn’t anything there.
- With this fix you can now run `bower install` from the `www` folder and:
   - Not receive errors from `h9 serve` or `h9 build`
   - `h9 build` will then properly copy all the bower components from the source (www/bower_components) to the target (build/bower_components) assuming you ran `bower install` from the www directory
   - `h9 build` will no longer leave odd/duplicate remnants in the `build/bower_components` folder due to processing files it shouldn’t