### PR TITLE
Correct CloudFront Distribution Origin Configuration For New Sites / Distributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [

--- a/src/publish/bucket/cloudfront/distribution.coffee
+++ b/src/publish/bucket/cloudfront/distribution.coffee
@@ -34,7 +34,8 @@ module.exports = async (config, cf) ->
 
 
   set = async (name) ->
-    buildSource = (name) -> name + ".s3.amazonaws.com"
+    buildSource = (name) ->
+      name + ".s3-website-" + config.aws.region + ".amazonaws.com"
 
     setViewerCertificate = async ->
       {ssl, protocol} = config.aws.cache
@@ -77,8 +78,15 @@ module.exports = async (config, cf) ->
           Quantity: 0
           Items: []
         OriginPath: ""
-        S3OriginConfig:
-          OriginAccessIdentity: ""
+        CustomOriginConfig:
+          HTTPPort: 80
+          HTTPSPort: 443
+          OriginProtocolPolicy: "http-only"
+          OriginSslProtocols:
+            Quantity: 1
+            Items: ["TLSv1.2"]
+          OriginReadTimeout: 30
+          OriginKeepaliveTimeout: 5
       ]
 
 


### PR DESCRIPTION
Even though AWS offers a configuration option to set the CloudFront origin as an S3 bucket, it comes out as a redirect thing that's not the static site.  So, I'm putting this back to a custom origin configuration, which restores the ability to publish new distributions and sites.