### PR TITLE
Implement Markdown Filter with Plugin to Fix Raw HTML Comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2815,30 +2815,6 @@
         "promise": "7.3.1"
       }
     },
-    "jstransformer-coffee-script": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jstransformer-coffee-script/-/jstransformer-coffee-script-1.1.0.tgz",
-      "integrity": "sha1-0ZHQhhkT2PayX9xBIVcm1QZPYqk=",
-      "requires": {
-        "coffee-script": "1.10.0",
-        "merge": "1.2.0"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
-          "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA="
-        }
-      }
-    },
-    "jstransformer-markdown-it": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer-markdown-it/-/jstransformer-markdown-it-2.0.0.tgz",
-      "integrity": "sha1-i0Su28lGXck10oC+kDObZxwWzrg=",
-      "requires": {
-        "markdown-it": "8.4.0"
-      }
-    },
     "jstransformer-stylus": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jstransformer-stylus/-/jstransformer-stylus-1.4.0.tgz",
@@ -2979,6 +2955,11 @@
         "uc.micro": "1.0.3"
       }
     },
+    "markdown-it-inline-comments": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-inline-comments/-/markdown-it-inline-comments-1.0.1.tgz",
+      "integrity": "sha1-F26r5jGj4IElvXOVAPQ8UfUliW0="
+    },
     "marked": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
@@ -3030,11 +3011,6 @@
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
       }
-    },
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -3378,16 +3354,12 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
     },
     "panda-9000": {
-      "version": "3.0.0-alpha-01",
-      "resolved": "https://registry.npmjs.org/panda-9000/-/panda-9000-3.0.0-alpha-01.tgz",
-      "integrity": "sha512-T/xLVA2cpHLvM06eDM2ywbIn4Kq7QGTXdtmTLqtcDgdYa93wp2c7RkEFnjcHylw69XIs6sJZt/Y2Bi6P/AXHEg==",
+      "version": "3.0.0-alpha-02",
+      "resolved": "https://registry.npmjs.org/panda-9000/-/panda-9000-3.0.0-alpha-02.tgz",
+      "integrity": "sha512-RSvSJs8KCwe6o7Zt83QW7bZWbBpNIGhSlDvIxTW39a/y/sTR/oF3eQ8AK3+B6DHMrhZoXBQoxLD4s5FCAU6U+g==",
       "requires": {
         "coffeescript": "2.0.2",
         "fairmont": "2.0.1",
-        "jstransformer-coffee-script": "1.1.0",
-        "jstransformer-markdown-it": "2.0.0",
-        "jstransformer-stylus": "1.4.0",
-        "marked": "0.3.6",
         "node-sass": "3.13.1",
         "panda-template": "0.3.0",
         "pug": "2.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [
@@ -27,11 +27,14 @@
     "fairmont": "2.0.1",
     "js-yaml": "^3.4.0",
     "jsck": "^0.3.0",
+    "jstransformer-stylus": "^1.4.0",
     "key-forge": "^0.1.3",
+    "markdown-it": "^8.4.0",
+    "markdown-it-inline-comments": "^1.0.1",
     "marked": "^0.3.5",
     "mime": "^1.3.4",
     "mime-types": "^2.1.6",
-    "panda-9000": "3.0.0-alpha-01",
+    "panda-9000": "3.0.0-alpha-02",
     "rimraf": "^2.4.3"
   },
   "devDependencies": {

--- a/src/survey/blog.coffee
+++ b/src/survey/blog.coffee
@@ -5,7 +5,7 @@ async, include, Type, isType,
 read, glob,
 Method} = require "fairmont"
 
-{define, context, pug} = require "panda-9000"
+{define, context} = require "panda-9000"
 {find, save, render} = Asset = require "../asset"
 {pathWithUnderscore} = require "../utils"
 Data = require "../data"
@@ -64,6 +64,8 @@ define "survey/posts", ["survey/markdown"], ->
     ]
 
 Method.define render, (isType type), async (asset) ->
+  {source} = require "../configuration"
+  pug = require("./helpers/pug")(source)
   for item in asset.data.items
     markdown = (yield read item.source.path).split( "<!-- more -->")[0]
     item.excerpt = marked markdown

--- a/src/survey/helpers/pug.coffee
+++ b/src/survey/helpers/pug.coffee
@@ -1,0 +1,13 @@
+{pug} = require "panda-9000"
+
+module.exports = (source) ->
+  options =
+    filters:
+      "markdown-it": (text) ->
+        md = do require "markdown-it"
+        md.use require "markdown-it-inline-comments"
+        md.render text
+
+  options.basedir = source if source
+
+  pug options

--- a/src/survey/markdown.coffee
+++ b/src/survey/markdown.coffee
@@ -2,7 +2,7 @@ marked = require "marked"
 {go, map, tee, reject, async, include,
 Type, isType, Method, glob, read} = require "fairmont"
 
-{define, context, pug} = require "panda-9000"
+{define, context} = require "panda-9000"
 {save, render} = Asset = require "../asset"
 Data = require "../data"
 {pathWithUnderscore, isBowerComponentsPath} = require "../utils"
@@ -23,6 +23,8 @@ define "survey/markdown", ["data"], ->
   ]
 
 Method.define render, (isType type), async (asset) ->
+  {source} = require "../configuration"
+  pug = require("./helpers/pug")(source)
   markdown = (yield read asset.source.path)
     .replace /\n/gm, "\n    "
     .replace /\#\{/g, '\\#{'

--- a/src/survey/pug.coffee
+++ b/src/survey/pug.coffee
@@ -3,7 +3,7 @@ include, Type, isType, isMatch,
 Method,
 glob} = require "fairmont"
 
-{define, context, pug} = require "panda-9000"
+{define, context} = require "panda-9000"
 {save, render} = Asset = require "../asset"
 Data = require "../data"
 {pathWithUnderscore, isBowerComponentsPath} = require "../utils"
@@ -23,4 +23,7 @@ define "survey/pug", ["data"], ->
     tee save
   ]
 
-Method.define render, (isType type), pug
+Method.define render, (isType type), (asset) ->
+  {source} = require "../configuration"
+  pug = require("./helpers/pug")(source)
+  pug asset


### PR DESCRIPTION
This leverages the Pug render options API that was just exposed in Panda-9000.  We now create our own markdown filter by pulling down the markdown-it package directly and adding the inline-comment plugin.  This gets around the weird behavior from the default jstransform module, where raw HTML comments were wrapped in paragraphs and then drawn on the page.  Now that doesn't happen any more.  😄 