### PR TITLE
Add Current Path Context to Pug Templates and Support Markdown Header Anchors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2955,6 +2955,14 @@
         "uc.micro": "1.0.3"
       }
     },
+    "markdown-it-anchor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-4.0.0.tgz",
+      "integrity": "sha1-6H+1VD4BllrfcVBsa/ewSRhBt+M=",
+      "requires": {
+        "string": "3.3.3"
+      }
+    },
     "markdown-it-inline-comments": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-inline-comments/-/markdown-it-inline-comments-1.0.1.tgz",
@@ -4279,6 +4287,11 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
       }
+    },
+    "string": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
+      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [
@@ -30,6 +30,7 @@
     "jstransformer-stylus": "^1.4.0",
     "key-forge": "^0.1.3",
     "markdown-it": "^8.4.0",
+    "markdown-it-anchor": "^4.0.0",
     "markdown-it-inline-comments": "^1.0.1",
     "marked": "^0.3.5",
     "mime": "^1.3.4",

--- a/src/survey/helpers/pug.coffee
+++ b/src/survey/helpers/pug.coffee
@@ -4,9 +4,10 @@ module.exports = (source) ->
   options =
     filters:
       "markdown-it": (text) ->
-        md = do require "markdown-it"
-        md.use require "markdown-it-inline-comments"
-        md.render text
+        md = require("markdown-it")()
+        .use require "markdown-it-inline-comments"
+        .use require "markdown-it-anchor"
+        .render text
 
   options.basedir = source if source
 

--- a/src/survey/pug.coffee
+++ b/src/survey/pug.coffee
@@ -1,6 +1,6 @@
 {go, map, tee, reject,
 include, Type, isType, isMatch,
-Method,
+Method, rest, last,
 glob} = require "fairmont"
 
 {define, context} = require "panda-9000"
@@ -26,4 +26,15 @@ define "survey/pug", ["data"], ->
 Method.define render, (isType type), (asset) ->
   {source} = require "../configuration"
   pug = require("./helpers/pug")(source)
+
+  # Generate a useful value for the file's path.  Add to _h9 dictionary.
+  path = asset.source.path.split("/")
+  if last(path) == "index.pug" || last(path) == "index.jade"
+    path = path.slice(0, path.length - 1) # Drop the final piece from the path.
+  else
+    # Drop the file extension.
+    path[path.length - 1] = last(path).replace(asset.source.extension, "")
+  path = "/" + rest(path).join("/")
+
+  asset.data._h9 = {path}
   pug asset


### PR DESCRIPTION
This adds the _h9 dictionary to all Pug templates so we can do cool things with sub-templates.  Currently only the "path" variable is exposed in that dictionary.  I also added a Pug markdown-it plugin that adds anchor-tags to the rendered markdown headers.  Now we're fucking professional!

This is the entry I just wrote into the Open Source section of the Panda Strike site:

### Default Variables

However, when using Pug files, there is one piece of context that H9 always gives to the templates. H9 gives a special `_h9` dictionary to the template's variable space. Currently that includes:

path: The current location of the Pug template with relation to the domain. For example, this page is located at `/open-source/haiku9/build`. The intention is to increase the expressive power of Pug sub-templates; to allow conditional presentation that depends on the location of the invoking template. Please note that this string omits file extensions and `/index` from paths.
The `_h9` dictionary may expand to include more powerful context in the future.