### PR TITLE
Guarantee Build Completes Before Task Returns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [

--- a/src/build.coffee
+++ b/src/build.coffee
@@ -17,4 +17,5 @@ define "build", ["survey"], async ->
         pull
         tee write target
       ]
+    pull
   ]


### PR DESCRIPTION
Added a pull to the bottom of the build reactive flow.  This has the flow wait until the file-write is complete before moving on.  Unfortunately, this also means assets are processed serially now.  Soon, Dan will come with an update to Fairmont to build a "go" that allows parallelism while waiting for all promises to resolve.