### PR TITLE
Correct ACM TLS Certificate Lookup Constraints for CloudFront

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.4",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku9",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Asset compilation, static-site generator",
   "main": "lib/index.js",
   "files": [

--- a/src/build.coffee
+++ b/src/build.coffee
@@ -5,9 +5,13 @@ rmrf = lift require "rimraf"
 {render} = Asset = require "./asset"
 
 define "build", ["survey"], async ->
+  console.log "Asset Pipeline"
+  console.log "===="
+  console.log "-- Wiping out build directory."
   {source, target} = require "./configuration"
   yield rmrf target
 
+  console.log "-- Building."
   yield go [
     Asset.iterator()
     tee async (formats) ->
@@ -19,3 +23,5 @@ define "build", ["survey"], async ->
       ]
     pull
   ]
+  console.log "-- Build complete."
+  console.log "===="

--- a/src/publish/bucket/cloudfront/acm.coffee
+++ b/src/publish/bucket/cloudfront/acm.coffee
@@ -1,4 +1,4 @@
-{async, collect, where, empty} = require "fairmont"
+{async, collect, where, empty, cat, compact, intersection, first, project} = require "fairmont"
 
 module.exports = (config, acm) ->
   # TODO: Consider how to handle multiple region cert placement.
@@ -6,36 +6,64 @@ module.exports = (config, acm) ->
 
   wild = (name) -> regularlyQualify "*." + root name
   apex = (name) -> regularlyQualify root name
+  needsApex = -> config.aws.domain in config.aws.hostnames
 
-  getCertList = async ->
-    data = yield acm.listCertificates CertificateStatuses: [ "ISSUED" ]
-    data.CertificateSummaryList
+  list = async (current=[], token) ->
+    params = CertificateStatuses: [ "ISSUED" ]
+    params.NextToken = token if token
+    {CertificateSummaryList, NextToken} = yield acm.listCertificates params
+    current = cat current, CertificateSummaryList
 
-  # Look for certs that contain wildcard permissions
+    if NextToken
+      yield list current, NextToken
+    else
+      current
+
+  # Looks through many certs looking for a given domain as the primary.
+  get = (name, list) -> collect where {DomainName: name}, list
+  wildGet = (name, list) -> get wild(name), list
+  apexGet = (name, list) -> get apex(name), list
+
+  # Looks within an individual cert for its coverage of a given domain.
+  scan = async (name, CertificateArn) ->
+    {Certificate} = yield acm.describeCertificate {CertificateArn}
+    alternates = Certificate.SubjectAlternativeNames
+    if name in alternates then CertificateArn else undefined
+
+  multiScan = async (name, list) ->
+    arns = (yield scan name, cert.CertificateArn for cert in list)
+    collect compact arns
+
+  wildScan = async (name, list) -> yield multiScan wild(name), list
+  apexScan = async (name, list) -> yield multiScan apex(name), list
+
+  containsWild = async (name, list) ->
+    wildArns = collect project "CertificateArn", wildGet(name, list)
+    certs = apexGet name, list
+    cat wildArns, yield wildScan(name, certs)
+
+  containsApex = async (name, list) ->
+    apexArns = collect project "CertificateArn", apexGet(name, list)
+    certs = wildGet name, list
+    cat apexArns, yield apexScan(name, certs)
+
+  hasBoth = async (name, list) ->
+    a = yield containsApex name, list
+    w = yield containsWild name, list
+    i = intersection a, w
+    if empty i then false else first i
+
   match = async (name, list) ->
-    certs = collect where {DomainName: wild name}, list
-    return certs[0].CertificateArn if !empty certs # Found what we need.
-
-    # No primary wildcard cert.  Look for apex.
-    certs = collect where {DomainName: apex name}, list
-    for cert in certs
-      data = yield acm.describeCertificate {CertificateArn: cert.CertificateArn}
-      alternates = data.Certificate.SubjectAlternativeNames
-      return cert.CertificateArn if wild(name) in alternates
-
-    false # Failed to find wildcard cert among alternate names.
+    if needsApex()
+      yield hasBoth name, list
+    else
+      certs = yield containsWild(name, list)
+      if empty certs then false else first certs
 
   fetch = async (name) ->
-    try
-      arn = yield match name, yield getCertList()
-    catch e
-      console.error "Unexpected response while searching SSL certs.", e
-      throw new Error()
-
-    if !arn
-      console.error "You do not have an active certificate for", wild name
-      throw new Error()
-    else
+    if arn = yield match name, yield list()
       arn
+    else
+      throw new Error "Unable to find the required certs in ACM."
 
   {fetch}


### PR DESCRIPTION
I reworked the certificate lookup to make sure the apex cert is required if the apex domain is invoked in a environment's configuration.  Added build logging to explain the pause that the start of publishing large codebases.